### PR TITLE
Add tag listing and search API endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -176,6 +176,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
   /api/tags:
+    get:
+      summary: List tags in the index
+      tags: [Tags]
+      parameters:
+        - in: query
+          name: path
+          schema:
+            type: string
+          description: Optional entry path to filter the results. When provided, the entry must exist.
+      responses:
+        '200':
+          description: Tag assignments currently stored in the index
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagListResponse'
+        '404':
+          description: Entry not found when filtering by path
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
     post:
       summary: Attach a tag to an entry
       tags: [Tags]
@@ -194,6 +216,37 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
         '400':
           description: Missing required fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/tags/search:
+    get:
+      summary: Search tag assignments
+      tags: [Tags]
+      parameters:
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+          description: Fuzzy search query applied to tag keys and values.
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+          description: Optional maximum number of matches to return (default 20).
+      responses:
+        '200':
+          description: Tag assignments matching the query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagSearchResponse'
+        '400':
+          description: Missing search query
           content:
             application/json:
               schema:
@@ -238,6 +291,46 @@ components:
         value:
           type: string
           description: Tag value.
+    TagAssignment:
+      allOf:
+        - $ref: '#/components/schemas/Tag'
+        - type: object
+          required: [path]
+          properties:
+            path:
+              type: string
+              description: Path of the entry the tag is attached to.
+    TagListResponse:
+      type: object
+      required: [tags]
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagAssignment'
+          description: Tag assignments currently stored in the index.
+    TagSearchResult:
+      allOf:
+        - $ref: '#/components/schemas/TagAssignment'
+        - type: object
+          properties:
+            pair:
+              type: string
+              description: Convenience representation in `key:value` format.
+            score:
+              type: number
+              format: float
+              nullable: true
+              description: Fuzzy match score where lower values are closer matches.
+    TagSearchResponse:
+      type: object
+      required: [results]
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/TagSearchResult'
+          description: Matching tag assignments ordered by relevance.
     GitRemote:
       type: object
       required: [name]


### PR DESCRIPTION
## Summary
- add GET /api/tags to retrieve all tag assignments or those associated with a specific path
- add GET /api/tags/search for fuzzy lookup of tag assignments with optional limits
- document the new endpoints and response structures in the OpenAPI specification

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdd3b73d988333b2d29e61a51dc595