### PR TITLE
Expose mounted filesystem path

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -471,7 +471,7 @@ components:
               description: Immediate child entries sorted by type then name.
     TreeResponse:
       type: object
-      required: [root, rootName, generatedAt]
+      required: [root, rootName, rootPath, generatedAt]
       properties:
         root:
           oneOf:
@@ -481,6 +481,9 @@ components:
         rootName:
           type: string
           description: Display name for the root directory being monitored.
+        rootPath:
+          type: string
+          description: Absolute path of the root directory being monitored.
         generatedAt:
           type: integer
           format: int64

--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,7 @@
   const state = {
     tree: null,
     rootName: '',
+    rootPath: '',
     expanded: new Set(['/']),
     selectedPath: null,
     filters: [],
@@ -29,6 +30,7 @@
     suggestions: document.getElementById('suggestions'),
     filters: document.getElementById('activeFilters'),
     tree: document.getElementById('tree'),
+    filesystemMeta: document.getElementById('filesystemMeta'),
     entryMeta: document.getElementById('entryMeta'),
     tagSection: document.getElementById('tagSection'),
     tagList: document.getElementById('tagList'),
@@ -55,6 +57,26 @@
   function setStatus(message) {
     if (els.status) {
       els.status.textContent = message;
+    }
+  }
+
+  function updateFilesystemMeta() {
+    if (!els.filesystemMeta) {
+      return;
+    }
+    const segments = [];
+    if (state.rootName) {
+      segments.push(state.rootName);
+    }
+    if (state.rootPath) {
+      segments.push(`Mounted at ${state.rootPath}`);
+    }
+    if (segments.length === 0) {
+      els.filesystemMeta.textContent = '';
+      els.filesystemMeta.classList.add('hidden');
+    } else {
+      els.filesystemMeta.textContent = segments.join(' • ');
+      els.filesystemMeta.classList.remove('hidden');
     }
   }
 
@@ -347,6 +369,8 @@
       const data = await fetchJSON('/api/tree');
       state.tree = data.root || null;
       state.rootName = data.rootName || '';
+      state.rootPath = data.rootPath || '';
+      updateFilesystemMeta();
       const available = new Set();
       if (state.tree) {
         collectPaths(state.tree, available);

--- a/public/index.html
+++ b/public/index.html
@@ -27,11 +27,14 @@
     </header>
     <main class="layout">
       <section class="panel tree-panel">
-        <div class="panel-header">Filesystem</div>
+        <div class="panel-header">
+          <span class="panel-title">Filesystem</span>
+          <span id="filesystemMeta" class="panel-meta hidden"></span>
+        </div>
         <div id="tree" class="tree"></div>
       </section>
       <section class="panel details-panel">
-        <div class="panel-header">Details</div>
+        <div class="panel-header"><span class="panel-title">Details</span></div>
         <div id="details">
           <div id="entryMeta" class="entry-meta empty">Select a file or directory.</div>
           <div id="fileSection" class="file-section hidden">
@@ -68,7 +71,7 @@
             <div id="tagFeedback" class="feedback"></div>
           </div>
         </div>
-        <div class="panel-header">Search Results</div>
+        <div class="panel-header"><span class="panel-title">Search Results</span></div>
         <div id="searchResults" class="results"></div>
       </section>
     </main>

--- a/public/style.css
+++ b/public/style.css
@@ -21,6 +21,10 @@ body {
   min-height: 100vh;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .app-header {
   display: flex;
   align-items: center;
@@ -170,9 +174,21 @@ body {
   font-weight: 600;
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--border);
+  color: var(--text-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.panel-title {
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--text-soft);
+}
+
+.panel-meta {
+  font-size: 0.75rem;
+  letter-spacing: normal;
+  text-transform: none;
 }
 
 .tree {

--- a/src/server.js
+++ b/src/server.js
@@ -919,7 +919,12 @@ function buildSuggestions(queryRaw) {
 
 app.get('/api/tree', (_req, res) => {
   const tree = buildTree();
-  res.json({ root: tree, rootName: path.basename(START_PATH), generatedAt: Date.now() });
+  res.json({
+    root: tree,
+    rootName: path.basename(START_PATH),
+    rootPath: START_PATH,
+    generatedAt: Date.now()
+  });
 });
 
 app.get('/api/search', (req, res) => {


### PR DESCRIPTION
## Summary
- include the monitored root path in the /api/tree response and OpenAPI schema
- surface the mounted filesystem path in the UI header so users can see the target mount point
- adjust header styling to accommodate the new metadata display

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cddd4d937083339a926b3b854718b5