### PR TITLE
Add healthz endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -26,6 +26,10 @@ const app = express();
 app.use(express.json({ limit: '2mb' }));
 app.use(express.static(PUBLIC_DIR));
 
+app.get('/healthz', (_req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
 app.get('/openapi.yaml', (_req, res, next) => {
   res.type('application/yaml');
   res.sendFile(OPENAPI_SPEC_PATH, (err) => {


### PR DESCRIPTION
## Summary
- add an Express route that responds to `/healthz` requests with a simple OK payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdf71ef33c83338abc9a4d989de0e0