### PR TITLE
Add example environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment configuration for better-fileexplorer
+# Copy this file to .env and adjust values as needed.
+
+# Port for the HTTP server (defaults to 4174 when unset)
+PORT=4174
+
+# Absolute filesystem path to serve as the starting directory
+# Defaults to the current working directory when not provided
+START_PATH=/absolute/path/to/start


### PR DESCRIPTION
## Summary
- add a `.env.example` template describing the `PORT` and `START_PATH` environment variables used by the server
- clarify the default behaviors for each variable and improve formatting for readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce2a14793c8333b4c5876c2daee6d3