### PR TITLE
Add SQLite indices to speed up search queries

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -81,6 +81,8 @@ db.exec(`
     extension TEXT,
     depth INTEGER NOT NULL
   );
+  CREATE INDEX IF NOT EXISTS idx_entries_depth_name
+    ON entries(depth, name COLLATE NOCASE);
   CREATE TABLE tags (
     id INTEGER PRIMARY KEY,
     entry_path TEXT NOT NULL,
@@ -89,6 +91,8 @@ db.exec(`
     UNIQUE(entry_path, key, value),
     FOREIGN KEY(entry_path) REFERENCES entries(path) ON DELETE CASCADE
   );
+  CREATE INDEX IF NOT EXISTS idx_tags_key_value
+    ON tags(key, value, entry_path);
   CREATE TABLE git_metadata (
     entry_path TEXT PRIMARY KEY,
     detected_at INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- add an index over entry depth and name so sorted listings reuse the database index
- create a composite index on tag key/value pairs to accelerate tag-filtered searches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf0ede41cc8333a51296e2a9b70d35