### PR TITLE
Add sortable file tree with aggregate metadata

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -442,6 +442,13 @@ components:
         depth:
           type: integer
           description: Depth from the root (root is 0).
+        totalSize:
+          type: integer
+          format: int64
+          description: Aggregate size in bytes including all descendant files. For files this matches `size`.
+        fileCount:
+          type: integer
+          description: Total number of files contained within the entry (files report 1).
         git:
           oneOf:
             - $ref: '#/components/schemas/GitMetadata'

--- a/public/index.html
+++ b/public/index.html
@@ -52,6 +52,20 @@
             <span class="panel-title block text-[0.65rem] tracking-[0.32em] text-neutral-500 dark:text-neutral-400">Filesystem</span>
             <span id="filesystemMeta" class="panel-meta hidden pt-2 text-[0.72rem] font-medium normal-case tracking-normal text-neutral-400 dark:text-neutral-500"></span>
           </div>
+          <div class="panel-toolbar flex flex-wrap items-center justify-between gap-3 border-b border-neutral-200 px-5 py-3 text-xs text-neutral-500 dark:border-neutral-800 dark:text-neutral-400">
+            <label for="sortSelect" class="flex items-center gap-2 text-[0.72rem] font-medium tracking-wide text-neutral-500 dark:text-neutral-400">
+              Sort by
+              <select
+                id="sortSelect"
+                class="rounded-xl border border-neutral-300 bg-white/70 px-3 py-1.5 text-xs text-neutral-700 shadow-sm outline-none transition focus:border-accent focus:ring-2 focus:ring-accent/40 dark:border-neutral-700 dark:bg-neutral-900/60 dark:text-neutral-100"
+              >
+                <option value="name">Name (A–Z)</option>
+                <option value="size">Size (largest first)</option>
+                <option value="modified">Modified (newest first)</option>
+                <option value="files">Files (most first)</option>
+              </select>
+            </label>
+          </div>
           <div id="tree" class="tree flex-1 overflow-y-auto p-4"></div>
         </section>
         <section class="panel details-panel flex min-h-0 flex-col gap-6 rounded-2xl border border-neutral-200 bg-white/80 shadow-sm backdrop-blur transition-colors dark:border-neutral-800 dark:bg-neutral-900/60">

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -732,6 +732,10 @@ video {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
 }
+.py-1\.5 {
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+}
 .py-2 {
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- compute aggregate sizes and file counts for entries and expose them through the tree and entry APIs
- add a tree toolbar with sorting controls and client-side comparators for name, size, modified time, and file totals
- show aggregated metrics in the details panel and document the new fields in the OpenAPI spec

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68cf11ff28b48333aaa358b24cd52fde